### PR TITLE
Add optional positional range for shiny broadcast

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,7 +28,7 @@ dependencies {
 
     // Cobblemon
     modImplementation("com.cobblemon:fabric:${property("cobblemon_version")}")
-    modImplementation("maven.modrinth:cobblemon-counter:${property("counter_version")}")
+    //modImplementation("maven.modrinth:cobblemon-counter:${property("counter_version")}")
 }
 
 tasks {

--- a/src/main/kotlin/us/timinc/mc/cobblemon/spawnnotification/SpawnNotification.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/spawnnotification/SpawnNotification.kt
@@ -5,9 +5,9 @@ import com.cobblemon.mod.common.api.events.entity.SpawnEvent
 import com.cobblemon.mod.common.entity.pokemon.PokemonEntity
 import com.cobblemon.mod.common.pokemon.Pokemon
 import com.cobblemon.mod.common.util.playSoundServer
-import com.cobblemon.mod.common.util.toBlockPos
 import net.fabricmc.api.ModInitializer
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerEntityEvents
+import net.minecraft.entity.player.PlayerEntity
 import net.minecraft.server.network.ServerPlayerEntity
 import net.minecraft.sound.SoundCategory
 import net.minecraft.sound.SoundEvent
@@ -15,13 +15,10 @@ import net.minecraft.text.Text
 import net.minecraft.util.Identifier
 import net.minecraft.util.math.BlockPos
 import net.minecraft.world.World
-import org.apache.logging.log4j.LogManager
 import us.timinc.mc.cobblemon.spawnnotification.config.SpawnNotificationConfig
 import us.timinc.mc.cobblemon.spawnnotification.util.Broadcast
 import us.timinc.mc.cobblemon.spawnnotification.util.PlayerUtil
 
-import net.minecraft.client.sound.SoundManager
-import net.minecraft.entity.player.PlayerEntity
 
 object SpawnNotification : ModInitializer {
     const val MOD_ID = "spawn_notification"

--- a/src/main/kotlin/us/timinc/mc/cobblemon/spawnnotification/SpawnNotification.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/spawnnotification/SpawnNotification.kt
@@ -42,7 +42,8 @@ object SpawnNotification : ModInitializer {
                 if (config.limitRange) {
                     val range = config.broadcastRange
                     val pos = evt.ctx.position
-                    val players = PlayerUtil.getPlayersInRange(pos, range)
+                    val dimensionKey = evt.ctx.world.dimensionKey
+                    val players = PlayerUtil.getPlayersInRange(pos, range, dimensionKey)
                     players.forEach { playShinySoundClient(it)}
                 } else {
                     playShinySound(evt.ctx.world, evt.ctx.position)
@@ -126,7 +127,8 @@ object SpawnNotification : ModInitializer {
         // if config.limitedRange && player.inRange()?
         if (config.limitRange) {
             val range = config.broadcastRange // config.range
-            val players: List<ServerPlayerEntity> = PlayerUtil.getPlayersInRange(pos, range)
+            val dimensionKey = evt.ctx.world.dimensionKey
+            val players: List<ServerPlayerEntity> = PlayerUtil.getPlayersInRange(pos, range, dimensionKey)
             Broadcast.broadcastMessage(players, messageComponent)
         } else {
             Broadcast.broadcastMessage(level, messageComponent)

--- a/src/main/kotlin/us/timinc/mc/cobblemon/spawnnotification/SpawnNotification.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/spawnnotification/SpawnNotification.kt
@@ -122,13 +122,10 @@ object SpawnNotification : ModInitializer {
             ))
 
             Broadcast.broadcastMessage(messageComponent)
-        }
-
-        // if config.limitedRange && player.inRange()?
-        val broadcastRange = config.broadcastRange
-        if (broadcastRange > 0) {
+        } else if (config.broadcastRange > 0) {
             val dimensionKey = evt.ctx.world.dimensionKey
-            val players: List<ServerPlayerEntity> = PlayerUtil.getPlayersInRange(pos, broadcastRange, dimensionKey)
+            val players: List<ServerPlayerEntity> = PlayerUtil.getPlayersInRange(pos, config.broadcastRange, dimensionKey)
+
             Broadcast.broadcastMessage(players, messageComponent)
         } else {
             Broadcast.broadcastMessage(level, messageComponent)

--- a/src/main/kotlin/us/timinc/mc/cobblemon/spawnnotification/SpawnNotification.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/spawnnotification/SpawnNotification.kt
@@ -43,7 +43,7 @@ object SpawnNotification : ModInitializer {
                 if (broadcastRange > 0) {
                     val pos = evt.ctx.position
                     val dimensionKey = evt.ctx.world.dimensionKey
-                    val players = PlayerUtil.getPlayersInRange(pos, broadcastRange, dimensionKey)
+                    val players = PlayerUtil.getValidPlayers(pos, broadcastRange, dimensionKey)
                     players.forEach { playShinySoundClient(it)}
                 } else {
                     playShinySound(evt.ctx.world, evt.ctx.position)
@@ -124,7 +124,7 @@ object SpawnNotification : ModInitializer {
             Broadcast.broadcastMessage(messageComponent)
         } else if (config.broadcastRange > 0) {
             val dimensionKey = evt.ctx.world.dimensionKey
-            val players: List<ServerPlayerEntity> = PlayerUtil.getPlayersInRange(pos, config.broadcastRange, dimensionKey)
+            val players: List<ServerPlayerEntity> = PlayerUtil.getValidPlayers(pos, config.broadcastRange, dimensionKey)
 
             Broadcast.broadcastMessage(players, messageComponent)
         } else {

--- a/src/main/kotlin/us/timinc/mc/cobblemon/spawnnotification/SpawnNotification.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/spawnnotification/SpawnNotification.kt
@@ -43,7 +43,8 @@ object SpawnNotification : ModInitializer {
                 if (broadcastRange > 0) {
                     val pos = evt.ctx.position
                     val dimensionKey = evt.ctx.world.dimensionKey
-                    val players = PlayerUtil.getValidPlayers(pos, broadcastRange, dimensionKey)
+                    val playerLimit = config.playerLimit
+                    val players = PlayerUtil.getValidPlayers(pos, broadcastRange, dimensionKey, playerLimit)
                     players.forEach { playShinySoundClient(it)}
                 } else {
                     playShinySound(evt.ctx.world, evt.ctx.position)
@@ -124,7 +125,8 @@ object SpawnNotification : ModInitializer {
             Broadcast.broadcastMessage(messageComponent)
         } else if (config.broadcastRange > 0) {
             val dimensionKey = evt.ctx.world.dimensionKey
-            val players: List<ServerPlayerEntity> = PlayerUtil.getValidPlayers(pos, config.broadcastRange, dimensionKey)
+            val playerLimit = config.playerLimit
+            val players: List<ServerPlayerEntity> = PlayerUtil.getValidPlayers(pos, config.broadcastRange, dimensionKey, playerLimit)
 
             Broadcast.broadcastMessage(players, messageComponent)
         } else {

--- a/src/main/kotlin/us/timinc/mc/cobblemon/spawnnotification/SpawnNotification.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/spawnnotification/SpawnNotification.kt
@@ -39,11 +39,11 @@ object SpawnNotification : ModInitializer {
 
             broadcastSpawn(evt)
             if (config.playShinySound && pokemon.shiny) {
-                if (config.limitRange) {
-                    val range = config.broadcastRange
+                val broadcastRange = config.broadcastRange
+                if (broadcastRange > 0) {
                     val pos = evt.ctx.position
                     val dimensionKey = evt.ctx.world.dimensionKey
-                    val players = PlayerUtil.getPlayersInRange(pos, range, dimensionKey)
+                    val players = PlayerUtil.getPlayersInRange(pos, broadcastRange, dimensionKey)
                     players.forEach { playShinySoundClient(it)}
                 } else {
                     playShinySound(evt.ctx.world, evt.ctx.position)
@@ -125,10 +125,10 @@ object SpawnNotification : ModInitializer {
         }
 
         // if config.limitedRange && player.inRange()?
-        if (config.limitRange) {
-            val range = config.broadcastRange // config.range
+        val broadcastRange = config.broadcastRange
+        if (broadcastRange > 0) {
             val dimensionKey = evt.ctx.world.dimensionKey
-            val players: List<ServerPlayerEntity> = PlayerUtil.getPlayersInRange(pos, range, dimensionKey)
+            val players: List<ServerPlayerEntity> = PlayerUtil.getPlayersInRange(pos, broadcastRange, dimensionKey)
             Broadcast.broadcastMessage(players, messageComponent)
         } else {
             Broadcast.broadcastMessage(level, messageComponent)

--- a/src/main/kotlin/us/timinc/mc/cobblemon/spawnnotification/config/SpawnNotificationConfig.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/spawnnotification/config/SpawnNotificationConfig.kt
@@ -23,11 +23,7 @@ class SpawnNotificationConfig {
     val broadcastDespawns = false
 
     val broadcastRange: Int = -1
-
-    // TODO: implement player limit
-    // Sort allPlayers by distance then only do up to X times
-    // Set to -1 for no limit
-//    val playerLimit: Int = -1
+    val playerLimit: Int = -1
 
     class Builder {
         companion object {

--- a/src/main/kotlin/us/timinc/mc/cobblemon/spawnnotification/config/SpawnNotificationConfig.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/spawnnotification/config/SpawnNotificationConfig.kt
@@ -22,7 +22,6 @@ class SpawnNotificationConfig {
     val announceCrossDimensions = false
     val broadcastDespawns = false
 
-    val limitRange = true
     val broadcastRange: Int = 16
 
     // TODO: implement player limit

--- a/src/main/kotlin/us/timinc/mc/cobblemon/spawnnotification/config/SpawnNotificationConfig.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/spawnnotification/config/SpawnNotificationConfig.kt
@@ -22,7 +22,7 @@ class SpawnNotificationConfig {
     val announceCrossDimensions = false
     val broadcastDespawns = false
 
-    val broadcastRange: Int = 16
+    val broadcastRange: Int = -1
 
     // TODO: implement player limit
     // Sort allPlayers by distance then only do up to X times

--- a/src/main/kotlin/us/timinc/mc/cobblemon/spawnnotification/config/SpawnNotificationConfig.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/spawnnotification/config/SpawnNotificationConfig.kt
@@ -22,6 +22,14 @@ class SpawnNotificationConfig {
     val announceCrossDimensions = false
     val broadcastDespawns = false
 
+    val limitRange = true
+    val broadcastRange: Int = 16
+
+    // TODO: implement player limit
+    // Sort allPlayers by distance then only do up to X times
+    // Set to -1 for no limit
+//    val playerLimit: Int = -1
+
     class Builder {
         companion object {
             fun load() : SpawnNotificationConfig {

--- a/src/main/kotlin/us/timinc/mc/cobblemon/spawnnotification/util/Broadcast.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/spawnnotification/util/Broadcast.kt
@@ -2,6 +2,7 @@ package us.timinc.mc.cobblemon.spawnnotification.util
 
 import com.cobblemon.mod.common.util.server
 import net.minecraft.server.world.ServerWorld
+import net.minecraft.server.network.ServerPlayerEntity
 import net.minecraft.text.Text
 
 object Broadcast {
@@ -13,5 +14,13 @@ object Broadcast {
 
     fun broadcastMessage(level: ServerWorld, message: Text) {
         level.players.forEach { it.sendMessage(message) }
+    }
+
+    fun broadcastMessage(players: List<ServerPlayerEntity>, message: Text) {
+        players.forEach { it.sendMessage(message) }
+    }
+
+    fun broadcastMessage(player: ServerPlayerEntity, message: Text) {
+        player.sendMessage(message)
     }
 }

--- a/src/main/kotlin/us/timinc/mc/cobblemon/spawnnotification/util/PlayerUtil.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/spawnnotification/util/PlayerUtil.kt
@@ -1,6 +1,5 @@
 package us.timinc.mc.cobblemon.spawnnotification.util
 
-import us.timinc.mc.cobblemon.spawnnotification.config.SpawnNotificationConfig
 import com.cobblemon.mod.common.util.server
 import net.minecraft.registry.RegistryKey
 import net.minecraft.server.network.ServerPlayerEntity
@@ -9,18 +8,17 @@ import net.minecraft.world.dimension.DimensionType
 import kotlin.math.sqrt
 
 object PlayerUtil {
-    private lateinit var config: SpawnNotificationConfig
-
     fun getValidPlayers(
         pos: BlockPos,
         range: Int,
-        dimensionKey: RegistryKey<DimensionType>
+        dimensionKey: RegistryKey<DimensionType>,
+        playerLimit: Int
     ): List<ServerPlayerEntity> {
         var playersInRange = getPlayersInRange(pos, range, dimensionKey)
 
-        if (config.playerLimit > 0) {
+        if (playerLimit > 0) {
             playersInRange = playersInRange.sortedBy { sqrt(pos.getSquaredDistance(it.pos)) }
-            playersInRange = playersInRange.take(config.playerLimit)
+            playersInRange = playersInRange.take(playerLimit)
         }
 
         return playersInRange

--- a/src/main/kotlin/us/timinc/mc/cobblemon/spawnnotification/util/PlayerUtil.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/spawnnotification/util/PlayerUtil.kt
@@ -1,0 +1,15 @@
+package us.timinc.mc.cobblemon.spawnnotification.util
+
+import com.cobblemon.mod.common.util.server
+import net.minecraft.server.network.ServerPlayerEntity
+import net.minecraft.util.math.BlockPos
+import kotlin.math.sqrt
+
+object PlayerUtil {
+    fun getPlayersInRange(pos: BlockPos, range: Int): List<ServerPlayerEntity> {
+        val serverInstance = server() ?: return emptyList()
+        val allPlayers = serverInstance.playerManager.playerList
+
+        return allPlayers.filter { sqrt(pos.getSquaredDistance(it.pos)) <= range }//.sortedBy { sqrt(pos.getSquaredDistance(it.pos)) }
+    }
+}

--- a/src/main/kotlin/us/timinc/mc/cobblemon/spawnnotification/util/PlayerUtil.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/spawnnotification/util/PlayerUtil.kt
@@ -1,5 +1,6 @@
 package us.timinc.mc.cobblemon.spawnnotification.util
 
+import us.timinc.mc.cobblemon.spawnnotification.config.SpawnNotificationConfig
 import com.cobblemon.mod.common.util.server
 import net.minecraft.registry.RegistryKey
 import net.minecraft.server.network.ServerPlayerEntity
@@ -8,10 +9,19 @@ import net.minecraft.world.dimension.DimensionType
 import kotlin.math.sqrt
 
 object PlayerUtil {
+    private lateinit var config: SpawnNotificationConfig
+
     fun getPlayersInRange(pos: BlockPos, range: Int, dimensionKey: RegistryKey<DimensionType>): List<ServerPlayerEntity> {
         val serverInstance = server() ?: return emptyList()
         val allPlayers = serverInstance.playerManager.playerList
 
-        return allPlayers.filter { sqrt(pos.getSquaredDistance(it.pos)) <= range && dimensionKey == it.world.dimensionKey}//.sortedBy { sqrt(pos.getSquaredDistance(it.pos)) }
+        var playersInRange = allPlayers.filter { sqrt(pos.getSquaredDistance(it.pos)) <= range && dimensionKey == it.world.dimensionKey}
+        playersInRange = playersInRange.sortedBy { sqrt(pos.getSquaredDistance(it.pos)) }
+
+        if (config.playerLimit > 0) {
+            playersInRange = playersInRange.take(config.playerLimit)
+        }
+
+        return playersInRange
     }
 }

--- a/src/main/kotlin/us/timinc/mc/cobblemon/spawnnotification/util/PlayerUtil.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/spawnnotification/util/PlayerUtil.kt
@@ -1,15 +1,17 @@
 package us.timinc.mc.cobblemon.spawnnotification.util
 
 import com.cobblemon.mod.common.util.server
+import net.minecraft.registry.RegistryKey
 import net.minecraft.server.network.ServerPlayerEntity
 import net.minecraft.util.math.BlockPos
+import net.minecraft.world.dimension.DimensionType
 import kotlin.math.sqrt
 
 object PlayerUtil {
-    fun getPlayersInRange(pos: BlockPos, range: Int): List<ServerPlayerEntity> {
+    fun getPlayersInRange(pos: BlockPos, range: Int, dimensionKey: RegistryKey<DimensionType>): List<ServerPlayerEntity> {
         val serverInstance = server() ?: return emptyList()
         val allPlayers = serverInstance.playerManager.playerList
 
-        return allPlayers.filter { sqrt(pos.getSquaredDistance(it.pos)) <= range }//.sortedBy { sqrt(pos.getSquaredDistance(it.pos)) }
+        return allPlayers.filter { sqrt(pos.getSquaredDistance(it.pos)) <= range && dimensionKey == it.world.dimensionKey}//.sortedBy { sqrt(pos.getSquaredDistance(it.pos)) }
     }
 }

--- a/src/main/kotlin/us/timinc/mc/cobblemon/spawnnotification/util/PlayerUtil.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/spawnnotification/util/PlayerUtil.kt
@@ -11,17 +11,29 @@ import kotlin.math.sqrt
 object PlayerUtil {
     private lateinit var config: SpawnNotificationConfig
 
-    fun getPlayersInRange(pos: BlockPos, range: Int, dimensionKey: RegistryKey<DimensionType>): List<ServerPlayerEntity> {
-        val serverInstance = server() ?: return emptyList()
-        val allPlayers = serverInstance.playerManager.playerList
-
-        var playersInRange = allPlayers.filter { sqrt(pos.getSquaredDistance(it.pos)) <= range && dimensionKey == it.world.dimensionKey}
-        playersInRange = playersInRange.sortedBy { sqrt(pos.getSquaredDistance(it.pos)) }
+    fun getValidPlayers(
+        pos: BlockPos,
+        range: Int,
+        dimensionKey: RegistryKey<DimensionType>
+    ): List<ServerPlayerEntity> {
+        var playersInRange = getPlayersInRange(pos, range, dimensionKey)
 
         if (config.playerLimit > 0) {
+            playersInRange = playersInRange.sortedBy { sqrt(pos.getSquaredDistance(it.pos)) }
             playersInRange = playersInRange.take(config.playerLimit)
         }
 
         return playersInRange
+    }
+
+    fun getPlayersInRange(
+        pos: BlockPos,
+        range: Int,
+        dimensionKey: RegistryKey<DimensionType>
+    ): List<ServerPlayerEntity> {
+        val serverInstance = server() ?: return emptyList()
+        val allPlayers = serverInstance.playerManager.playerList
+
+        return allPlayers.filter { sqrt(pos.getSquaredDistance(it.pos)) <= range && dimensionKey == it.world.dimensionKey }
     }
 }


### PR DESCRIPTION
Add `bool limitRange` and `int broadcastRange` to config and added logic to implement a range a player has to be within of a spawn to be notified. I also added `playShinySoundClient()` to add flexibility for who is notified even potentially nearby a spawn.

I can't remember if I started this because of #9 or #11, but I'm not sure I've really properly implemented either of them yet. I'll add an option for something like "only notify the X closest players" to appease #9 once you're okay with how I'm going about adding code to your project first.